### PR TITLE
Forward-compatibility with DIALS 2.1

### DIFF
--- a/FormatCBFGatanOneView.py
+++ b/FormatCBFGatanOneView.py
@@ -185,7 +185,10 @@ class FormatCBFGatanOneView(FormatCBF):
             )
         elif no_compression:
             from boost.python import streambuf
-            from dxtbx.ext import read_int32
+            try:
+                from dxtbx.ext import read_int32
+            except ImportError:
+                from dxtbx import read_int32
             from scitbx.array_family import flex
 
             assert len(self.get_detector()) == 1

--- a/FormatCBFGatanOneView.py
+++ b/FormatCBFGatanOneView.py
@@ -185,7 +185,7 @@ class FormatCBFGatanOneView(FormatCBF):
             )
         elif no_compression:
             from boost.python import streambuf
-            from dxtbx import read_int32
+            from dxtbx.ext import read_int32
             from scitbx.array_family import flex
 
             assert len(self.get_detector()) == 1

--- a/FormatFalconIIRaw.py
+++ b/FormatFalconIIRaw.py
@@ -58,7 +58,10 @@ class FormatFalconIIRaw(Format):
         """Get the pixel intensities"""
 
         from boost.python import streambuf
-        from dxtbx.ext import read_int16
+        try:
+            from dxtbx.ext import read_int16
+        except ImportError:
+            from dxtbx import read_int16
         from scitbx.array_family import flex
 
         f = FormatFalconIIRaw.open_file(self._image_file, "rb")

--- a/FormatFalconIIRaw.py
+++ b/FormatFalconIIRaw.py
@@ -58,7 +58,7 @@ class FormatFalconIIRaw(Format):
         """Get the pixel intensities"""
 
         from boost.python import streambuf
-        from dxtbx import read_int16
+        from dxtbx.ext import read_int16
         from scitbx.array_family import flex
 
         f = FormatFalconIIRaw.open_file(self._image_file, "rb")

--- a/FormatTIFFeBIC.py
+++ b/FormatTIFFeBIC.py
@@ -154,9 +154,9 @@ class FormatTIFFeBIC(Format):
         from scitbx.array_family import flex
 
         if self._bytes_per_pixel == 2:
-            from dxtbx import read_uint16 as read_pixel
+            from dxtbx.ext import read_uint16 as read_pixel
         else:
-            from dxtbx import read_uint8 as read_pixel
+            from dxtbx.ext import read_uint8 as read_pixel
 
         f = FormatTIFFeBIC.open_file(self._image_file, "rb")
         f.seek(self._data_offset)

--- a/FormatTIFFeBIC.py
+++ b/FormatTIFFeBIC.py
@@ -153,10 +153,14 @@ class FormatTIFFeBIC(Format):
         from boost.python import streambuf
         from scitbx.array_family import flex
 
+        try:
+            import dxtbx.ext as _dxtbx_ext
+        except ImportError:
+            import dxtbx as _dxtbx_ext
         if self._bytes_per_pixel == 2:
-            from dxtbx.ext import read_uint16 as read_pixel
+            read_pixel = _dxtbx_ext.read_uint16
         else:
-            from dxtbx.ext import read_uint8 as read_pixel
+            read_pixel = _dxtbx_ext.read_uint8
 
         f = FormatTIFFeBIC.open_file(self._image_file, "rb")
         f.seek(self._data_offset)

--- a/FormatTimepixRaw512x512.py
+++ b/FormatTimepixRaw512x512.py
@@ -74,7 +74,7 @@ class FormatTimepixRaw512x512(Format):
         """Get the pixel intensities"""
 
         from boost.python import streambuf
-        from dxtbx import read_uint16_bs
+        from dxtbx.ext import read_uint16_bs
         from scitbx.array_family import flex
 
         f = FormatTimepixRaw512x512.open_file(self._image_file, "rb")

--- a/FormatTimepixRaw512x512.py
+++ b/FormatTimepixRaw512x512.py
@@ -74,7 +74,10 @@ class FormatTimepixRaw512x512(Format):
         """Get the pixel intensities"""
 
         from boost.python import streambuf
-        from dxtbx.ext import read_uint16_bs
+        try:
+            from dxtbx.ext import read_uint16_bs
+        except ImportError:
+            from dxtbx import read_uint16_bs
         from scitbx.array_family import flex
 
         f = FormatTimepixRaw512x512.open_file(self._image_file, "rb")


### PR DESCRIPTION
`dxtbx.*` will no longer redirect to `dxtbx.ext.*`, so need to import names from `.ext` directly