### PR TITLE
Rigorous definition of `trusted_range`

### DIFF
--- a/FormatCBFGatanOneView.py
+++ b/FormatCBFGatanOneView.py
@@ -103,10 +103,10 @@ class FormatCBFGatanOneView(FormatCBF):
         nx = int(self._cif_header_dictionary["X-Binary-Size-Fastest-Dimension"])
         ny = int(self._cif_header_dictionary["X-Binary-Size-Second-Dimension"])
 
-        overload = dxtbx_overload_scale * int(
+        max_trusted = dxtbx_overload_scale * int(
             self._cif_header_dictionary["Count_cutoff"].split()[0]
         )
-        underload = -1
+        min_trusted = 0
 
         detector = self._detector_factory.simple(
             "PAD",
@@ -116,7 +116,7 @@ class FormatCBFGatanOneView(FormatCBF):
             "-y",
             (1000 * pixel_x, 1000 * pixel_y),
             (nx, ny),
-            (underload, overload),
+            (min_trusted, max_trusted),
             [],
         )
 

--- a/FormatCBFJungfrauVIE01.py
+++ b/FormatCBFJungfrauVIE01.py
@@ -83,8 +83,8 @@ class FormatCBFJungfrauVIE01(FormatCBF):
 
         pixel_x, pixel_y = map(float, pixel_xy)
 
-        overload = int(self._header_dictionary["Count_cutoff"].split()[0])
-        underload = -1
+        max_trusted = int(self._header_dictionary["Count_cutoff"].split()[0])
+        min_trusted = 0
 
         detector = self._detector_factory.simple(
             "PAD",
@@ -94,7 +94,7 @@ class FormatCBFJungfrauVIE01(FormatCBF):
             "-y",
             (1000 * pixel_x, 1000 * pixel_y),
             (nx, ny),
-            (underload, overload),
+            (min_trusted, max_trusted),
             [],
         )
 

--- a/FormatCBFMiniTimepix.py
+++ b/FormatCBFMiniTimepix.py
@@ -121,7 +121,7 @@ class FormatCBFMiniTimepix(FormatCBFMini):
 
         # 55 mu pixels
         pixel_size = 0.055, 0.055
-        trusted_range = (-1, 65535)
+        trusted_range = (0, 65535)
         material = "Si"
         thickness = 0.3  # assume 300 mu thick. This is actually in the header too
         # so could take it from there

--- a/FormatFalconIIRaw.py
+++ b/FormatFalconIIRaw.py
@@ -85,7 +85,7 @@ class FormatFalconIIRaw(Format):
 
         pixel_size = 0.028, 0.028
         image_size = 2048, 2048
-        trusted_range = (-1, 65535)
+        trusted_range = (0, 65535)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range

--- a/FormatMIB.py
+++ b/FormatMIB.py
@@ -209,7 +209,7 @@ class FormatMIB(Format):
             if "-bit" in word:
                 dyn_range = int(word.replace("-bit", ""))
                 break
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (0, 2 ** dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range

--- a/FormatNXmxSINGLA.py
+++ b/FormatNXmxSINGLA.py
@@ -122,7 +122,7 @@ class FormatNexusSINGLA(FormatNXmx):
         pixel_size = self._pixel_size
         image_size = self._image_size
         dyn_range = self._bit_depth_readout
-        trusted_range = (-1, 2**dyn_range - 1)
+        trusted_range = (0, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range

--- a/FormatNexusSINGLA.py
+++ b/FormatNexusSINGLA.py
@@ -132,6 +132,9 @@ class FormatNexusSINGLA(FormatNexus):
         pixel_size = self._pixel_size
         image_size = self._image_size
         dyn_range = self._bit_depth_readout
+        # trusted_range is not updated here following https://github.com/cctbx/dxtbx/pull/536
+        # because this Format class is specifically for use with DIALS <= 3.10, in which
+        # those changes are not present.
         trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(

--- a/FormatSMV4DSTEM.py
+++ b/FormatSMV4DSTEM.py
@@ -30,7 +30,7 @@ class FormatSMV4DSTEM(FormatSMVADSC):
         binning = {"1x1": 1, "2x2": 2}.get(self._header_dictionary.get("BIN"), 1)
         gain = 1.0
         saturation = 65535 #?
-        trusted_range = (-1, saturation)
+        trusted_range = (0, saturation)
         pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
 
         return self._detector_factory.simple(

--- a/FormatSMV_TVIPS.py
+++ b/FormatSMV_TVIPS.py
@@ -80,7 +80,7 @@ class FormatSMV_TVIPS(FormatSMVADSC):
     def _detector(self):
         pixel_size = 0.0311999992, 0.0311999992
         image_size = 2048, 2048
-        trusted_range = (-2, 65535)
+        trusted_range = (-1, 65535) # Unsure what is correct here
         gain = 5  # As suggested for processing with MOSFLM - unsure how right this is
         distance = float(self._header_dictionary["DISTANCE"])
         beam_x = float(self._header_dictionary["BEAM_CENTER_X"])

--- a/FormatTIFF_DE.py
+++ b/FormatTIFF_DE.py
@@ -79,7 +79,7 @@ class FormatTIFF_DE(FormatTIFF):
 
         pixel_size = 0.013, 0.013
         image_size = 4096, 4096
-        trusted_range = (-1, 65535)
+        trusted_range = (0, 65535)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 700, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range

--- a/FormatTIFFgeneric.py
+++ b/FormatTIFFgeneric.py
@@ -122,7 +122,7 @@ class FormatTIFFgeneric_Merlin(FormatTIFFgeneric):
         pixel_size = 0.055, 0.055
         image_size = (512, 512)
         dyn_range = 12
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (0, 2 ** dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range

--- a/FormatTimepixRaw512x512.py
+++ b/FormatTimepixRaw512x512.py
@@ -110,7 +110,7 @@ class FormatTimepixRaw512x512(Format):
         # 55 mu pixels
         pixel_size = 0.055, 0.055
         image_size = 512, 512
-        trusted_range = (-1, 65535)
+        trusted_range = (0, 65535)
         material = "Si"
         thickness = 0.3  # assume 300 mu thick
 


### PR DESCRIPTION
Changes to adapt to https://github.com/cctbx/dxtbx/pull/536.

This should be merged when those changes are published in a released version of DIALS (3.12?). In the period after https://github.com/cctbx/dxtbx/pull/536 is merged but _before_ that makes it into a release, then users of developer installs of DIALS up-to-date with dxtbx and DIALS repositories should pull ED format classes from this branch rather than the master branch.

Once this branch is merged, the format classes in this repository will not be intended for use with earlier versions of DIALS. Unfortunately there is no way to check that, but if users run into problems they can always override `trusted_range` on import.