### PR TITLE
FormatTIFFgeneric_Timepix516

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+repos:
+# Syntax validation and some basic sanity checks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: check-merge-conflict
+  - id: check-ast
+    fail_fast: True
+  - id: check-json
+  - id: check-added-large-files
+    args: ['--maxkb=200']
+  - id: check-yaml
+    args: ['--allow-multiple-documents']
+
+# Automatically sort imports
+- repo: https://github.com/PyCQA/isort
+  rev: 5.12.0
+  hooks:
+  - id: isort
+    args: [
+           '-a', 'from __future__ import annotations',        # 3.7-3.11
+           '--rm', 'from __future__ import absolute_import',  # -3.0
+           '--rm', 'from __future__ import division',         # -3.0
+           '--rm', 'from __future__ import generator_stop',   # -3.7
+           '--rm', 'from __future__ import generators',       # -2.3
+           '--rm', 'from __future__ import nested_scopes',    # -2.2
+           '--rm', 'from __future__ import print_function',   # -3.0
+           '--rm', 'from __future__ import unicode_literals', # -3.0
+           '--rm', 'from __future__ import with_statement',   # -2.6
+           "--profile", "black",
+          ]
+    exclude: ^installer/
+
+# Automatic source code formatting
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+  - id: black
+    args: [--safe, --quiet]
+    files: \.pyi?$|SConscript$|^libtbx_config$
+    types: [file]
+
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v13.0.1
+  hooks:
+  - id: clang-format
+    files: \.c(c|pp|xx)?$|\.h(pp)?$
+
+# Linting
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+    args: ['--ignore=E501,E203']
+    additional_dependencies: ['flake8-comprehensions==3.8.0']
+

--- a/FormatCBFGatanOneView.py
+++ b/FormatCBFGatanOneView.py
@@ -8,7 +8,7 @@
 #  https://github.com/cctbx/cctbx_project/blob/master/dxtbx/license.txt
 #
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 
@@ -149,8 +149,9 @@ class FormatCBFGatanOneView(FormatCBF):
         return ScanFactory.make_scan((index, index), 0.0, (0, 1), {index: 0})
 
     def read_cbf_image(self, cbf_image):
-        from cbflib_adaptbx import uncompress
         import binascii
+
+        from cbflib_adaptbx import uncompress
 
         start_tag = binascii.unhexlify("0c1a04d5")
 

--- a/FormatCBFJungfrauVIE01.py
+++ b/FormatCBFJungfrauVIE01.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 
@@ -139,8 +139,9 @@ class FormatCBFJungfrauVIE01(FormatCBF):
         return ScanFactory.make_scan((index, index), 0.0, (0, 1), {index: 0})
 
     def read_cbf_image(self, cbf_image):
-        from cbflib_adaptbx import uncompress
         import binascii
+
+        from cbflib_adaptbx import uncompress
 
         start_tag = binascii.unhexlify("0c1a04d5")
 

--- a/FormatCBFMiniEigerQuadro.py
+++ b/FormatCBFMiniEigerQuadro.py
@@ -1,7 +1,8 @@
 """Experimental format class for miniCBF files from an ELDICO diffractometer,
 which uses a DECTRIS QUADRO detector (EIGER technology)"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
 import os
 
 from dxtbx.format.FormatCBFMiniEiger import FormatCBFMiniEiger
@@ -37,7 +38,7 @@ class FormatCBFMiniEigerQuadro(FormatCBFMiniEiger):
         """Axis as determined by a single run of dials.find_rotation_axis, so
         probably not exact"""
 
-        return self._goniometer_factory.known_axis((-0.0540788,0.998537,0))
+        return self._goniometer_factory.known_axis((-0.0540788, 0.998537, 0))
 
     def _beam(self):
         """Ensure an unpolarised beam"""
@@ -129,6 +130,3 @@ class FormatCBFMiniEigerQuadro(FormatCBFMiniEiger):
             panel.set_mu(1e10)
 
         return detector
-
-
-

--- a/FormatCBFMiniTimepix.py
+++ b/FormatCBFMiniTimepix.py
@@ -18,14 +18,15 @@ data array for a moduleis 512*512 pixels and the wide pixels are excluded from
 the active region of the detector. The formats here recognise these cases
 based on the resulting data array size and act accordingly."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
 import os
 
 from dxtbx.format.FormatCBFMini import FormatCBFMini
-from dxtbx.model.detector import Detector
 from dxtbx.model import ScanFactory
-from scitbx.array_family import flex
 from dxtbx.model.beam import Probe
+from dxtbx.model.detector import Detector
+from scitbx.array_family import flex
 
 
 class FormatCBFMiniTimepix(FormatCBFMini):

--- a/FormatFalconIIRaw.py
+++ b/FormatFalconIIRaw.py
@@ -10,14 +10,14 @@
 """Experimental implementation of a format class to recognise raw images
 from an FEI Falcon II detector"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 
 from dxtbx.format.Format import Format
 from dxtbx.model import ScanFactory
-from dxtbx.model.detector import Detector
 from dxtbx.model.beam import Probe
+from dxtbx.model.detector import Detector
 
 
 class FormatFalconIIRaw(Format):

--- a/FormatMIB.py
+++ b/FormatMIB.py
@@ -1,14 +1,18 @@
 """Experimental implementation of a format class to recognise raw images
 from a Quantum Detectors Merlin device in MIB file format"""
 
+from __future__ import annotations
+
+import os
+
+import numpy as np
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 from dxtbx.model import ScanFactory
-from dxtbx.model.detector import Detector
-import numpy as np
-import os
-from scitbx.array_family import flex
 from dxtbx.model.beam import Probe
+from dxtbx.model.detector import Detector
+from scitbx.array_family import flex
+
 
 # The mib_properties class and get_mib_properties, processedMib and loadMib
 # functions are provided by Quantum Detectors Ltd. as example code (without
@@ -217,7 +221,7 @@ class FormatMIB(Format):
             if "-bit" in word:
                 dyn_range = int(word.replace("-bit", ""))
                 break
-        trusted_range = (0, 2 ** dyn_range - 1)
+        trusted_range = (0, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         # Following discussion with QD, I think the origin of the image array
         # is at the bottom left (as viewed by dials.image_viewer), with fast

--- a/FormatNXmxSINGLA.py
+++ b/FormatNXmxSINGLA.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import math
 
+import dxtbx.nexus
 import h5py
 import nxmx
-
-from libtbx import Auto
-
-import dxtbx.nexus
 from dxtbx.format.FormatNXmx import FormatNXmx
-from dxtbx.masking import GoniometerMaskerFactory
-from dxtbx.masking import mask_untrusted_circle, mask_untrusted_polygon
+from dxtbx.masking import (
+    GoniometerMaskerFactory,
+    mask_untrusted_circle,
+    mask_untrusted_polygon,
+)
 from dxtbx.model.beam import Probe
-
+from libtbx import Auto
 from scitbx.array_family import flex
 
 
@@ -169,9 +169,9 @@ class FormatNXmxSINGLA(FormatNXmx):
             # if 32 bit then it is a signed int, I think if 8, 16 then it is
             # unsigned with the highest two values assigned as masking values
             if self._bit_depth_readout == 32:
-                top = 2 ** 31
+                top = 2**31
             else:
-                top = 2 ** self._bit_depth_readout
+                top = 2**self._bit_depth_readout
             for data in raw_data:
                 d1d = data.as_1d()
                 d1d.set_selected(d1d == top - 1, -1)

--- a/FormatNexusSINGLA.py
+++ b/FormatNexusSINGLA.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import math
 
+import dxtbx.nexus
 import h5py
 import nxmx
-
-from libtbx import Auto
-
-import dxtbx.nexus
 from dxtbx.format.FormatNexus import FormatNexus
-from dxtbx.masking import GoniometerMaskerFactory
-from dxtbx.masking import mask_untrusted_circle, mask_untrusted_polygon
+from dxtbx.masking import (
+    GoniometerMaskerFactory,
+    mask_untrusted_circle,
+    mask_untrusted_polygon,
+)
 from dxtbx.model.beam import Probe
-
+from libtbx import Auto
 from scitbx.array_family import flex
 
 
@@ -182,9 +182,9 @@ class FormatNexusSINGLA(FormatNexus):
             # if 32 bit then it is a signed int, I think if 8, 16 then it is
             # unsigned with the highest two values assigned as masking values
             if self._bit_depth_readout == 32:
-                top = 2 ** 31
+                top = 2**31
             else:
-                top = 2 ** self._bit_depth_readout
+                top = 2**self._bit_depth_readout
             for data in raw_data:
                 d1d = data.as_1d()
                 d1d.set_selected(d1d == top - 1, -1)

--- a/FormatSEReBICpedestal.py
+++ b/FormatSEReBICpedestal.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 # FormatSEReBICpedestal.py
 
+from __future__ import annotations
+
 # Experimental format for TIA .ser files used by FEI microscope at eBIC. This
 # version adds a pedestal level to the image data as determined by the
 # environment variable ADD_PEDESTAL. A warning will be issued to counter
 # against the use of this format by mistake
-
-from __future__ import absolute_import, division, print_function
-
-import os
 import logging
+import os
 
 from dxtbx.format.FormatSEReBIC import FormatSEReBIC
 from dxtbx.model.beam import Probe

--- a/FormatSMV4DSTEM.py
+++ b/FormatSMV4DSTEM.py
@@ -1,7 +1,8 @@
 """Format class to recognise images from a camera used for 4D-STEM measurements
 (https://doi.org/10.1017/S1431927620019753), which have been converted to SMV"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
 import os
 
 from dxtbx.format.FormatSMVADSC import FormatSMVADSC
@@ -31,7 +32,7 @@ class FormatSMV4DSTEM(FormatSMVADSC):
         # Assume GAIN=1 as counting
         binning = {"1x1": 1, "2x2": 2}.get(self._header_dictionary.get("BIN"), 1)
         gain = 1.0
-        saturation = 65535 #?
+        saturation = 65535  # ?
         trusted_range = (0, saturation)
 
         pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))

--- a/FormatSMVCetaD_TUI.py
+++ b/FormatSMVCetaD_TUI.py
@@ -3,7 +3,8 @@ in rolling shutter mode that have been converted to SMV with useful metadata. We
 want to override the beam model to produce an unpolarised beam and to set the
 detector gain to something sensible"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
 import os
 
 from dxtbx.format.FormatSMVADSC import FormatSMVADSC
@@ -39,7 +40,7 @@ class FormatSMVCetaD_TUI(FormatSMVADSC):
         # according to Thermo Fisher
         binning = {"1x1": 1, "2x2": 2}.get(self._header_dictionary.get("BIN"), 1)
         gain = float(self._header_dictionary.get("GAIN", 26.0))
-        saturation = 8000 * binning ** 2
+        saturation = 8000 * binning**2
         trusted_range = (-1000, saturation)
         pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
 

--- a/FormatSMVFalcon4.py
+++ b/FormatSMVFalcon4.py
@@ -5,7 +5,8 @@ by Max Clabbers. This is apparently relevant for the detector in 'electron
 counting' mode. This Format class must be activated by an environment variable
 to avoid clashes with other formats."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
 import os
 
 from dxtbx.format.FormatSMVADSC import FormatSMVADSC
@@ -36,7 +37,7 @@ class FormatSMVFalcon4(FormatSMVADSC):
         # according to Thermo Fisher
         binning = {"1x1": 1, "2x2": 2}.get(self._header_dictionary.get("BIN"), 1)
         gain = float(self._header_dictionary.get("GAIN", 32.0))
-        saturation = 8000 * binning ** 2  # Guesswork
+        saturation = 8000 * binning**2  # Guesswork
         trusted_range = (0, saturation)
         pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
 

--- a/FormatSMVFalconIII.py
+++ b/FormatSMVFalconIII.py
@@ -3,7 +3,7 @@ ThermoFisher Falcon III detector that have been converted to SMV with useful
 metadata. We want to override the beam model to produce an unpolarised beam
 and to set the detector gain to something sensible"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from dxtbx.format.FormatSMVADSC import FormatSMVADSC
 from dxtbx.model.beam import Probe

--- a/FormatSMV_TVIPS.py
+++ b/FormatSMV_TVIPS.py
@@ -13,14 +13,14 @@ This is intended specifically for processing of the Trypsin datasets available
 at https://data.sbgrid.org/dataset/288/, but could be adapted for other
 datasets produced in a similar manner."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 import time
 
 from dxtbx.format.FormatSMVADSC import FormatSMVADSC
-from dxtbx.model.detector import Detector
 from dxtbx.model.beam import Probe
+from dxtbx.model.detector import Detector
 
 
 class FormatSMV_TVIPS(FormatSMVADSC):
@@ -81,7 +81,7 @@ class FormatSMV_TVIPS(FormatSMVADSC):
     def _detector(self):
         pixel_size = 0.0311999992, 0.0311999992
         image_size = 2048, 2048
-        trusted_range = (-1, 65535) # Unsure what is correct here
+        trusted_range = (-1, 65535)  # Unsure what is correct here
         gain = 5  # As suggested for processing with MOSFLM - unsure how right this is
         distance = float(self._header_dictionary["DISTANCE"])
         beam_x = float(self._header_dictionary["BEAM_CENTER_X"])

--- a/FormatTIFF_DE.py
+++ b/FormatTIFF_DE.py
@@ -1,23 +1,19 @@
 """Experimental implementation of a format class to recognise images in TIFF
 format recorded on an electron microscope with a Direct Electron (DE) detector."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
-import os
 import io
-from PIL import Image
-from dxtbx.format.FormatTIFF import FormatTIFF
-from dxtbx.format.FormatTIFFHelpers import read_basic_tiff_header
-from dxtbx.format.FormatTIFFHelpers import BIG_ENDIAN
-from dxtbx.model import ScanFactory
+import os
+
 from boost.python import streambuf
-from scitbx.array_family import flex
-from dxtbx.ext import (
-    read_uint8,
-    read_uint16,
-    read_uint16_bs,
-)
+from dxtbx.ext import read_uint8, read_uint16, read_uint16_bs
+from dxtbx.format.FormatTIFF import FormatTIFF
+from dxtbx.format.FormatTIFFHelpers import BIG_ENDIAN, read_basic_tiff_header
+from dxtbx.model import ScanFactory
 from dxtbx.model.beam import Probe
+from PIL import Image
+from scitbx.array_family import flex
 
 
 class FormatTIFF_DE(FormatTIFF):

--- a/FormatTIFFgeneric.py
+++ b/FormatTIFFgeneric.py
@@ -1,16 +1,19 @@
 """A format class for generic TIFF images plus implementations for specific
 detectors producing electron diffraction data"""
 
-import os
+from __future__ import annotations
+
 import io
+import os
+import re
+
+from dxtbx import flumpy
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatStill import FormatStill
-from scitbx.array_family import flex
-import re
-from dxtbx import flumpy
+from dxtbx.masking import mask_untrusted_rectangle
 from dxtbx.model.beam import Probe
 from dxtbx.model.detector import Detector
-from dxtbx.masking import mask_untrusted_rectangle
+from scitbx.array_family import flex
 
 try:
     import tifffile
@@ -126,7 +129,7 @@ class FormatTIFFgeneric_Merlin(FormatTIFFgeneric):
         pixel_size = 0.055, 0.055
         image_size = (512, 512)
         dyn_range = 12
-        trusted_range = (0, 2 ** dyn_range - 1)
+        trusted_range = (0, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
@@ -177,7 +180,7 @@ class FormatTIFFgeneric_Timepix512(FormatTIFFgeneric):
         cntr = matrix.col((0.0, 0.0, -100.0))
 
         # shifts to go from the centre to the origin - outer pixels are 0.165 mm
-        self._array_size = (512,512)
+        self._array_size = (512, 512)
         off_x = (self._array_size[0] / 2 - 2) * pixel_size[0]
         off_x += 2 * 0.165
         shift_x = -1.0 * fast * off_x
@@ -306,6 +309,7 @@ class FormatTIFFgeneric_Timepix512(FormatTIFFgeneric):
 
         return tuple(self._raw_data)
 
+
 class FormatTIFFgeneric_Timepix516(FormatTIFFgeneric):
     """An experimental image reading class for TIFF images from a Timepix
     detectors with 516x516 pixels where the central cross is masked out.
@@ -362,7 +366,7 @@ class FormatTIFFgeneric_Timepix516(FormatTIFFgeneric):
         pixel_size = 0.055, 0.055
         image_size = (516, 516)
         dyn_range = 12
-        trusted_range = (0, 2 ** dyn_range - 1)
+        trusted_range = (0, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
@@ -414,7 +418,7 @@ class FormatTIFFgeneric_ASI(FormatTIFFgeneric):
         pixel_size = 0.055, 0.055
         image_size = (516, 516)
         dyn_range = 20  # XXX ?
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
@@ -467,7 +471,7 @@ class FormatTIFFgeneric_FEI_Tecnai_G2(FormatTIFFgeneric):
         pixel_size = 0.026, 0.026
         image_size = (1024, 1024)
         dyn_range = 14  # XXX ?
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
@@ -522,12 +526,13 @@ class FormatTIFFgeneric_Medipix(FormatTIFFgeneric):
         pixel_size = 0.055, 0.055
         image_size = (514, 514)
         dyn_range = 16
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
         )
         return d
+
 
 class FormatTIFFgeneric_BlochwaveSim(FormatTIFFgeneric):
     """Format class to process headerless TIFF images produced by Tarik Drevon's
@@ -563,12 +568,13 @@ class FormatTIFFgeneric_BlochwaveSim(FormatTIFFgeneric):
         pixel_size = 0.028, 0.028
         image_size = (2048, 2048)
         dyn_range = 16
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 834, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
         )
         return d
+
 
 class FormatTIFF_UED(FormatTIFFgeneric, FormatStill):
     """An experimental image reading class for TIFF images from a UED
@@ -610,7 +616,7 @@ class FormatTIFF_UED(FormatTIFFgeneric, FormatStill):
         pixel_size = 0.060, 0.060
         image_size = (1300, 1340)
         dyn_range = 20  # No idea what is correct
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "PAD", 2440, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range
@@ -663,7 +669,7 @@ class FormatTIFF_UED_BNL(FormatTIFFgeneric, FormatStill):
         pixel_size = 0.016, 0.016
         image_size = (512, 512)
         dyn_range = 20  # No idea what is correct
-        trusted_range = (-1, 2 ** dyn_range - 1)
+        trusted_range = (-1, 2**dyn_range - 1)
         beam_centre = [(p * i) / 2 for p, i in zip(pixel_size, image_size)]
         d = self._detector_factory.simple(
             "CCD", 3480, beam_centre, "+x", "-y", pixel_size, image_size, trusted_range

--- a/FormatTimepixRaw512x512.py
+++ b/FormatTimepixRaw512x512.py
@@ -11,14 +11,14 @@
 from a detector with a 2x2 array of Timepix modules, used in electron
 diffraction experiments"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 
 from dxtbx.format.Format import Format
 from dxtbx.model import ScanFactory
-from dxtbx.model.detector import Detector
 from dxtbx.model.beam import Probe
+from dxtbx.model.detector import Detector
 
 
 class FormatTimepixRaw512x512(Format):

--- a/FormatVelox.py
+++ b/FormatVelox.py
@@ -2,18 +2,19 @@
 read metadata from the files are taken from from yamtbx by @keitaroyam. See
 https://github.com/keitaroyam/yamtbx/blob/master/dxtbx_formats/FormatEMD.py"""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
-import os
-import h5py
 import json
-from scitbx.array_family import flex
+import os
+
+import h5py
 import numpy
+from dxtbx import IncorrectFormatError
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatHDF5 import FormatHDF5
 from dxtbx.format.FormatMultiImage import FormatMultiImage
-from dxtbx import IncorrectFormatError
 from dxtbx.model.beam import Probe
+from scitbx.array_family import flex
 
 
 def get_metadata(metadata):
@@ -117,7 +118,7 @@ class FormatVelox(FormatHDF5):
         voltage = float(metadata[0]["Optics"]["AccelerationVoltage"])
         ret["wavelength"] = (
             h
-            / numpy.sqrt(2 * m0 * e * voltage * (1.0 + e * voltage / 2.0 / m0 / c ** 2))
+            / numpy.sqrt(2 * m0 * e * voltage * (1.0 + e * voltage / 2.0 / m0 / c**2))
             * 1.0e10
         )
 
@@ -177,10 +178,10 @@ class FormatVelox(FormatHDF5):
 
         if "ceta" in camera:
             gain = 26.0
-            saturation = 8000 * binning ** 2
+            saturation = 8000 * binning**2
         elif "falcon" in camera:
             gain = 1.0
-            saturation = 8000 * binning ** 2
+            saturation = 8000 * binning**2
         else:
             gain = 1.0
             saturation = 1e6


### PR DESCRIPTION
- Added a Format class plugin for $516\times516$ pixel images from a Timepix detector, where the central cross is masked out
- Added pre-commits for this repo, and committed changes they made
- Set up a consistent way of controlling rather unspecific TIFF format classes by environment variables